### PR TITLE
feat: replace Biconomy with internal meta-tx-gateway

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   prejob:
     name: Get Latest Tag
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       releaseTag: ${{ steps.tag.outputs.tag }}
       releaseName: ${{ steps.name.outputs.name }}
@@ -87,7 +87,7 @@ jobs:
 
   job-summary:
     name: Create Job Summary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
     needs:
       [

--- a/.github/workflows/ci_reusable.yaml
+++ b/.github/workflows/ci_reusable.yaml
@@ -48,7 +48,7 @@ on:
 jobs:
   build-test-deploy:
     name: Build, Test and Deploy the Hosted Widgets
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       REACT_APP_ENV_NAME: ${{ inputs.REACT_APP_ENV_NAME }}
       REACT_APP_RELEASE_TAG: ${{ inputs.REACT_APP_RELEASE_TAG }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@bosonprotocol/react-kit": "^0.34.0",
+        "@bosonprotocol/react-kit": "^0.35.1-alpha.7",
         "@krakenjs/zoid": "^10.3.3",
         "@svgr/webpack": "^8.1.0",
         "@testing-library/jest-dom": "^5.16.5",
@@ -55,7 +55,8 @@
         "path-browserify": "^1.0.1",
         "prettier": "^2.8.8",
         "react-app-rewired": "^2.2.1",
-        "shx": "^0.3.4"
+        "shx": "^0.3.4",
+        "yup": "^1.5.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2156,28 +2157,45 @@
         "yup": "^0.32.11"
       }
     },
+    "node_modules/@bosonprotocol/chat-sdk/node_modules/yup": {
+      "version": "0.32.11",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
+      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/lodash": "^4.14.175",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "nanoclone": "^0.2.1",
+        "property-expr": "^2.0.4",
+        "toposort": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@bosonprotocol/common": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/common/-/common-1.29.0.tgz",
-      "integrity": "sha512-TlRucPiPXrqgSEAgz6dwlArdkPO2HZcgnZan3IJo5x58YM0QbxMtvdPseUIpOwgkIF9vEE8346tYiA+CdrXyZw==",
+      "version": "1.30.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/common/-/common-1.30.0-alpha.7.tgz",
+      "integrity": "sha512-sN+nnI+Zem0NwYlz9bEMxnzBKDnGLHZiVZKJp+ixgbv+kH6TWTJCXfh3YVSHbzJEIySqsDxiX5djtX2gBvYHuA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bosonprotocol/metadata": "^1.16.2",
+        "@bosonprotocol/metadata": "^1.16.3-alpha.3",
         "@ethersproject/abi": "^5.5.0",
         "@ethersproject/address": "^5.5.0",
         "@ethersproject/bignumber": "^5.5.0",
         "@ethersproject/constants": "^5.5.0",
-        "@ethersproject/units": "^5.5.0",
-        "yup": "^0.32.11"
+        "@ethersproject/units": "^5.5.0"
       }
     },
     "node_modules/@bosonprotocol/core-sdk": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/core-sdk/-/core-sdk-1.41.0.tgz",
-      "integrity": "sha512-3qYW3j+bsAVv3necppqFtRBhtg3m8po25UVJ6Btq8G1o05YSqt5eiGrX6SWWlWXjw2XSsju29rR9oSpqyu0HKg==",
+      "version": "1.42.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/core-sdk/-/core-sdk-1.42.0-alpha.1.tgz",
+      "integrity": "sha512-dJnTPEAyslLYdTmAHhunefR/nO+TxB1W0a5/6RKXghSVGYxefeBK0M+LHMPbKWnONyTOriWEjJzpJ1uUfLVGFg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bosonprotocol/common": "^1.29.0",
+        "@bosonprotocol/common": "^1.30.0-alpha.7",
         "@ethersproject/abi": "^5.5.0",
         "@ethersproject/address": "^5.5.0",
         "@ethersproject/bignumber": "^5.5.0",
@@ -2189,8 +2207,7 @@
         "graphql-request": "^4.3.0",
         "mustache": "^4.2.0",
         "opensea-js": "^7.1.13",
-        "schema-to-yup": "^1.11.11",
-        "yup": "^0.32.11"
+        "schema-to-yup": "^1.11.11"
       }
     },
     "node_modules/@bosonprotocol/core-sdk/node_modules/graphql-request": {
@@ -2208,12 +2225,12 @@
       }
     },
     "node_modules/@bosonprotocol/ethers-sdk": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/ethers-sdk/-/ethers-sdk-1.15.0.tgz",
-      "integrity": "sha512-Ceg9iNyJV9Ppe/xtPbaWko8MqwebckNxo2Nou/kvjun+LXfwXi/xK5WzjWAvRqcqk+exy7qxbKC+Zw8Sp93PKQ==",
+      "version": "1.15.1-alpha.7",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/ethers-sdk/-/ethers-sdk-1.15.1-alpha.7.tgz",
+      "integrity": "sha512-qzGxx17jHAEGMybPKuFpNXFXGIgbYhuX74Oe+mJPBD65sF5xbjRrEIGErtmpL5SKfC96klrsnoXKZAaMNNbdQA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bosonprotocol/common": "^1.29.0"
+        "@bosonprotocol/common": "^1.30.0-alpha.7"
       },
       "peerDependencies": {
         "ethers": "^5.5.0"
@@ -2232,13 +2249,14 @@
       }
     },
     "node_modules/@bosonprotocol/metadata": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/metadata/-/metadata-1.16.2.tgz",
-      "integrity": "sha512-yA99IO+BHvc3AkCba/fsrrXr3npb7zxwPvz8PUJ9qrKd7Gid95hE5V5sG9tpbeNc/UuErQ3wX8G5pmitVNlaIQ==",
+      "version": "1.16.3-alpha.3",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/metadata/-/metadata-1.16.3-alpha.3.tgz",
+      "integrity": "sha512-4fe588oZXH+B7LPOQwRXFnOMpR5Th3ifk1Yt6rO4S1tAt6B2cgDI5lVBSJDNF/tcppBr01MTreJjp8sQjxFkTg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bosonprotocol/metadata-storage": "^1.0.1",
-        "schema-to-yup": "^1.11.11"
+        "schema-to-yup": "^1.11.11",
+        "yup": "^1.5.0"
       }
     },
     "node_modules/@bosonprotocol/metadata-storage": {
@@ -2248,14 +2266,14 @@
       "license": "Apache-2.0"
     },
     "node_modules/@bosonprotocol/react-kit": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/react-kit/-/react-kit-0.34.0.tgz",
-      "integrity": "sha512-Smf6kplGcCT0E7UYq+oI1pnQqhguecNnITbToQ09MKiOOo9Idklo6Xe2BhHLuYxKyakGNmTevKh0/zuDz7Yc4A==",
+      "version": "0.35.1-alpha.7",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/react-kit/-/react-kit-0.35.1-alpha.7.tgz",
+      "integrity": "sha512-TBgqR8YP4veqpvaD1X42msJuXF96HwjCHbH7Qp7etN4Z1Ebm8zarjKjujFIImokqfQ9xD+ytDqZepZwFb6RjKA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bosonprotocol/chat-sdk": "^1.3.1-alpha.9",
-        "@bosonprotocol/core-sdk": "^1.41.0",
-        "@bosonprotocol/ethers-sdk": "^1.15.0",
+        "@bosonprotocol/core-sdk": "^1.42.0-alpha.1",
+        "@bosonprotocol/ethers-sdk": "^1.15.1-alpha.7",
         "@bosonprotocol/ipfs-storage": "^1.12.0",
         "@davatar/react": "1.11.1",
         "@ethersproject/units": "5.6.0",
@@ -2319,13 +2337,13 @@
         "use-resize-observer": "^9.1.0",
         "utility-types": "3.10.0",
         "viem": "^1.21.4",
-        "wagmi": "^1.4.13",
-        "yup": "0.32.11"
+        "wagmi": "^1.4.13"
       },
       "peerDependencies": {
         "ethers": "^5.7.2",
         "react": "17 - 18",
-        "react-dom": "17 - 18"
+        "react-dom": "17 - 18",
+        "yup": "^1.5.0"
       }
     },
     "node_modules/@bosonprotocol/react-kit/node_modules/@emotion/unitless": {
@@ -8078,9 +8096,10 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.196",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.196.tgz",
-      "integrity": "sha512-22y3o88f4a94mKljsZcanlNWPzO0uBsBdzLAngf2tp533LzZcQzb6+eZPJ+vCTt+bqF2XnvT9gejTLsAcJAJyQ=="
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
+      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==",
+      "license": "MIT"
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
@@ -22852,7 +22871,8 @@
     "node_modules/nanoclone": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
-      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
+      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.6",
@@ -27657,30 +27677,6 @@
         "yup": "^1.0.0"
       }
     },
-    "node_modules/schema-to-yup/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/schema-to-yup/node_modules/yup": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-1.4.0.tgz",
-      "integrity": "sha512-wPbgkJRCqIf+OHyiTBQoJiP5PFuAXaWiJK6AmYkzQAh5/c2K9hzSApBZG5wV9KoKSePF7sAxmNSvh/13YHkFDg==",
-      "license": "MIT",
-      "dependencies": {
-        "property-expr": "^2.0.5",
-        "tiny-case": "^1.0.3",
-        "toposort": "^2.0.2",
-        "type-fest": "^2.19.0"
-      }
-    },
     "node_modules/schema-utils": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
@@ -31891,20 +31887,27 @@
       }
     },
     "node_modules/yup": {
-      "version": "0.32.11",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
-      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.5.0.tgz",
+      "integrity": "sha512-NJfBIHnp1QbqZwxcgl6irnDMIsb/7d1prNhFx02f1kp8h+orpi4xs3w90szNpOh68a/iHPdMsYvhZWoDmUvXBQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "@types/lodash": "^4.14.175",
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21",
-        "nanoclone": "^0.2.1",
-        "property-expr": "^2.0.4",
-        "toposort": "^2.0.2"
-      },
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/yup/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     ]
   },
   "dependencies": {
-    "@bosonprotocol/react-kit": "^0.34.0",
+    "@bosonprotocol/react-kit": "^0.35.1-alpha.7",
     "@krakenjs/zoid": "^10.3.3",
     "@svgr/webpack": "^8.1.0",
     "@testing-library/jest-dom": "^5.16.5",
@@ -90,6 +90,7 @@
     "path-browserify": "^1.0.1",
     "prettier": "^2.8.8",
     "react-app-rewired": "^2.2.1",
-    "shx": "^0.3.4"
+    "shx": "^0.3.4",
+    "yup": "^1.5.0"
   }
 }

--- a/src/components/widgets/commitButton/CommitButton.tsx
+++ b/src/components/widgets/commitButton/CommitButton.tsx
@@ -80,26 +80,35 @@ export function CommitButton() {
     }
   }, [props]);
   useEffect(() => {
-    let resizeObserver: ResizeObserver;
     if (ref.current) {
       const resizeObserver = new ResizeObserver(() => {
         sendDimensions();
       });
 
       resizeObserver.observe(ref.current);
+      return () => {
+        resizeObserver?.disconnect();
+      };
     }
-    return () => {
-      resizeObserver?.disconnect();
-    };
+    return () => undefined;
   }, [sendDimensions]);
   const buttonStyleObj = useMemo(() => {
     const buttonStyleValidated = yup
       .object({
         minWidth: yupStringOrNumber,
         minHeight: yupStringOrNumber,
-        shape: yup.mixed().oneOf(["sharp", "rounded", "pill"]).optional(),
-        color: yup.mixed().oneOf(["green", "black", "white"]).optional(),
-        layout: yup.mixed().oneOf(["vertical", "horizontal"]).optional()
+        shape: yup
+          .mixed<"sharp" | "rounded" | "pill">()
+          .oneOf(["sharp", "rounded", "pill"])
+          .optional(),
+        color: yup
+          .mixed<"green" | "black" | "white">()
+          .oneOf(["green", "black", "white"])
+          .optional(),
+        layout: yup
+          .mixed<"vertical" | "horizontal">()
+          .oneOf(["vertical", "horizontal"])
+          .optional()
       })
       .validateSync(buttonStyle);
     if (typeof buttonStyle === "object") {
@@ -111,7 +120,15 @@ export function CommitButton() {
     const containerStyleValidated = yup
       .object({
         justifyContent: yup
-          .mixed()
+          .mixed<
+            | "initial"
+            | "flex-start"
+            | "flex-end"
+            | "center"
+            | "space-between"
+            | "space-around"
+            | "space-evenly"
+          >()
           .oneOf([
             "initial",
             "flex-start",
@@ -123,7 +140,14 @@ export function CommitButton() {
           ])
           .optional(),
         alignItems: yup
-          .mixed()
+          .mixed<
+            | "initial"
+            | "flex-start"
+            | "flex-end"
+            | "center"
+            | "baseline"
+            | "stretch"
+          >()
           .oneOf([
             "initial",
             "flex-start",

--- a/src/components/widgets/commitButton/CommitButton.tsx
+++ b/src/components/widgets/commitButton/CommitButton.tsx
@@ -90,7 +90,6 @@ export function CommitButton() {
         resizeObserver?.disconnect();
       };
     }
-    return () => undefined;
   }, [sendDimensions]);
   const buttonStyleObj = useMemo(() => {
     const buttonStyleValidated = yup

--- a/src/components/widgets/purchaseOverview/PurchaseOverview.tsx
+++ b/src/components/widgets/purchaseOverview/PurchaseOverview.tsx
@@ -20,7 +20,7 @@ export const PurchaseOverview = () => {
     return yup
       .object({
         modalMargin: yup.string().optional(),
-        bodyOverflow: yup.string().optional().nullable(true)
+        bodyOverflow: yup.string().optional().nullable()
       })
       .validateSync(props);
   }, [props]);


### PR DESCRIPTION
## Description

- Core components dependencies are upgraded to use the internal meta-tx gateway instead of Biconomy.

## How to test

Check the network connection when submitting a transaction.
FYI, here are the new Urls, per env:
- testing: https://meta-tx-gateway-testing-114403180314.europe-west2.run.app
- staging: https://meta-tx-gateway-staging-114403180314.europe-west2.run.app
- production: https://meta-tx-gateway-114403180314.europe-west2.run.app

see more here: https://github.com/bosonprotocol/meta-tx-gateway/blob/main/docs/deployments.md